### PR TITLE
スタイルを調整

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,6 +22,10 @@ $fa-font-path: "@fortawesome/fontawesome-free/webfonts";
 @import "@fortawesome/fontawesome-free/scss/solid";
 @import "@fortawesome/fontawesome-free/scss/brands";
 
+body {
+  padding-top: 60px;
+}
+
 .field_with_errors {
   display: contents;
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,6 +26,6 @@ $fa-font-path: "@fortawesome/fontawesome-free/webfonts";
   display: contents;
 
   input {
-    border: 2px solid red;
+    @extend .is-invalid;
   }
 }

--- a/app/views/layouts/_error_messages.html.erb
+++ b/app/views/layouts/_error_messages.html.erb
@@ -1,6 +1,6 @@
 <% if resource.errors.any? %>
-  <div>
-    <ul>
+  <div class="alert alert-danger" role="alert">
+    <ul class="mb-0">
       <% resource.errors.full_messages.each do |msg| %>
         <li><%= msg %></li>
       <% end %>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,8 +1,12 @@
 <% flash.each do |msg_type, msg| %>
   <% if msg_type == "notice" %>
-    <p style="color: green;"><%= msg %></p>
+    <div class="alert alert-success" role="alert">
+      <%= msg %>
+    </div>
   <% else %>
-    <p style="color: red;"><%= msg %></p>
+    <div class="alert alert-danger" role="alert">
+      <%= msg %>
+    </div>
   <% end %>
   <hr>
 <% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,16 +1,18 @@
-<nav class="navbar navbar-expand-lg navbar-light bg-light">
-  <%= link_to "MESSAGE", posts_path, class: "navbar-brand" %>
-  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
-    <span class="navbar-toggler-icon"></span>
-  </button>
-  <div class="collapse navbar-collapse" id="navbarNav">
-    <ul class="navbar-nav">
-      <li class="nav-item">
-        <%= link_to "投稿一覧", posts_path, class: "nav-link" %>
-      </li>
-      <li class="nav-item">
-        <%= link_to "新規投稿", new_post_path, class: "nav-link" %>
-      </li>
-    </ul>
-  </div>
-</nav>
+<div class='fixed-top'>
+  <nav class="navbar navbar-expand-lg navbar-light bg-light">
+    <%= link_to "MESSAGE", posts_path, class: "navbar-brand" %>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav">
+        <li class="nav-item">
+          <%= link_to "投稿一覧", posts_path, class: "nav-link" %>
+        </li>
+        <li class="nav-item">
+          <%= link_to "新規投稿", new_post_path, class: "nav-link" %>
+        </li>
+      </ul>
+    </div>
+  </nav>
+</div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,2 +1,16 @@
-<%= link_to "投稿一覧", posts_path %> <%= link_to "新規投稿", new_post_path %>
-<hr>
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
+  <%= link_to "MESSAGE", posts_path, class: "navbar-brand" %>
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarNav">
+    <ul class="navbar-nav">
+      <li class="nav-item">
+        <%= link_to "投稿一覧", posts_path, class: "nav-link" %>
+      </li>
+      <li class="nav-item">
+        <%= link_to "新規投稿", new_post_path, class: "nav-link" %>
+      </li>
+    </ul>
+  </div>
+</nav>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
     <title>CrudSampleApp</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,8 @@
   <body>
     <%= render "layouts/header" %>
     <%= render "layouts/flash" %>
-    <%= yield %>
+    <div class="container-fluid mt-5" style="max-width: 600px;">
+      <%= yield %>
+    </div>
   </body>
 </html>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,14 +1,14 @@
 <%= render "layouts/error_messages", resource: post %>
 <%= form_with model: post, local: true do |form| %>
-  <div>
+  <div class="form-group">
     <%= form.label :title %>
-    <%= form.text_field :title %>
+    <%= form.text_field :title, class: "form-control" %>
   </div>
-  <div>
+  <div class="form-group">
     <%= form.label :content %>
-    <%= form.text_field :content %>
+    <%= form.text_field :content, class: "form-control" %>
   </div>
   <div>
-    <%= form.submit button_value %>
+    <%= form.submit button_value, class: "btn btn-primary" %>
   </div>
 <% end %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,12 +1,13 @@
-<%= render "layouts/error_messages", resource: post %>
 <%= form_with model: post, local: true do |form| %>
   <div class="form-group">
     <%= form.label :title %>
-    <%= form.text_field :title, class: "form-control" %>
+    <%= form.text_field :title, class: "form-control #{'is-invalid' if post.errors.full_messages_for(:title).present?}" %>
+    <%= render 'form_errors', resource: post, column: :title %>
   </div>
   <div class="form-group">
     <%= form.label :content %>
-    <%= form.text_field :content, class: "form-control" %>
+    <%= form.text_field :content, class: "form-control #{'is-invalid' if post.errors.full_messages_for(:content).present?}" %>
+    <%= render 'form_errors',resource: post, column: :content %>
   </div>
   <div>
     <%= form.submit button_value, class: "btn btn-primary" %>

--- a/app/views/posts/_form_errors.html.erb
+++ b/app/views/posts/_form_errors.html.erb
@@ -1,0 +1,3 @@
+<div class="invalid-feedback">
+  <%= resource.errors.full_messages_for(column).join(", ") %>
+</div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -10,9 +10,21 @@
     <% @posts.each do |post| %>
       <tr>
         <td><%= post.title %></td>
-        <td><%= link_to "詳細", post %></td>
-        <td><%= link_to "編集", edit_post_path(post) %></td>
-        <td><%= link_to "削除", post, method: :delete, data: { confirm: "削除しますか?" } %></td>
+        <td>
+          <%= link_to post, class: "btn btn-info" do %>
+            <i class="far fa-file-alt"></i> 詳細
+          <% end %>
+        </td>
+        <td>
+          <%= link_to edit_post_path(post), class: "btn btn-success" do %>
+            <i class="far fa-edit"></i> 編集
+          <% end %>
+        </td>
+        <td>
+          <%= link_to post, method: :delete, data: { confirm: "削除しますか?" }, class: "btn btn-danger" do %>
+            <i class="far fa-trash-alt"></i> 削除
+          <% end %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,5 +1,5 @@
 <h1>投稿一覧</h1>
-<table>
+<table class="table">
   <thead>
     <tr>
       <th>タイトル</th>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -2,27 +2,27 @@
 <table class="table">
   <thead>
     <tr>
-      <th>タイトル</th>
+      <th class="w-100">タイトル</th>
       <th colspan="3"></th>
     </tr>
   </thead>
   <tbody>
     <% @posts.each do |post| %>
       <tr>
-        <td><%= post.title %></td>
-        <td>
+        <td class="align-middle"><%= post.title %></td>
+        <td class="text-nowrap">
           <%= link_to post, class: "btn btn-info" do %>
-            <i class="far fa-file-alt"></i> 詳細
+            <i class="far fa-file-alt"></i><span class="d-none d-sm-inline"> 詳細</span>
           <% end %>
         </td>
-        <td>
+        <td class="text-nowrap">
           <%= link_to edit_post_path(post), class: "btn btn-success" do %>
-            <i class="far fa-edit"></i> 編集
+            <i class="far fa-edit"></i><span class="d-none d-sm-inline"> 編集</span>
           <% end %>
         </td>
-        <td>
+        <td class="text-nowrap">
           <%= link_to post, method: :delete, data: { confirm: "削除しますか?" }, class: "btn btn-danger" do %>
-            <i class="far fa-trash-alt"></i> 削除
+            <i class="far fa-trash-alt"></i><span class="d-none d-sm-inline"> 削除</span>
           <% end %>
         </td>
       </tr>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,3 +1,7 @@
-<h1>投稿詳細</h1>
-<p>タイトル <%= @post.title %></p>
-<p>本文 <%= @post.content %></p>
+<div class="card border-dark mb-3">
+  <div class="card-body">
+    <h4 class="card-title"><%= @post.title %></h4>
+    <p class="card-text"><%= @post.content %></p>
+    <%= link_to "戻る", posts_path, class: "btn btn-primary" %>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ module CrudSampleApp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
     config.i18n.default_locale = :ja
+    config.action_view.field_error_proc = Proc.new { |html_tag, instance| html_tag }
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
### 概要

アプリのスタイルをBootstrapを利用し調整

## 内容

- ヘッダーをナビバーにしてTOPに固定
- 投稿一覧のテーブルにBootstrapを適用
- 投稿一覧の詳細、編集、削除をボタンにしてアイコンも表示
- 投稿詳細をカードで表示
- タイトル、本文が空だった場合にエラー文をフォームの下に表示し、フォームが赤くなるように設定
- レスポンシブ対応